### PR TITLE
Fix: traverse headers.entries() should use for of

### DIFF
--- a/src/xhr-middleware.js
+++ b/src/xhr-middleware.js
@@ -148,7 +148,7 @@ export default function startProxyingXhr({
 
         // Initiate actual request
         actual.open(method, url, async, user, pw)
-        for (const tuple in headers.entries()) {
+        for (const tuple of headers.entries()) {
           actual.setRequestHeader(tuple[0], tuple[1])
         }
         actual.send(body)


### PR DESCRIPTION
Thank you very much for your amazing work! But when I try this code, I found a bug, so I pull this request to fix it .